### PR TITLE
Added support for moved business days

### DIFF
--- a/business_calendar/test/test_business_calendar.py
+++ b/business_calendar/test/test_business_calendar.py
@@ -386,6 +386,7 @@ class TestCalendarWesternWeek(BaseCalendarTest):
             count = self.cal.workdaycount('Dec 31, 2009', date2);
             assert count == daycount
 
+
 class TestCalendarCrazyWeek(BaseCalendarTest):
     @classmethod
     def setup_class(cls):
@@ -403,6 +404,7 @@ class TestCalendarCrazyWeek(BaseCalendarTest):
                                 datetime.datetime(2013,12,31),
                                 inc=True)
 
+
 class TestCalendarWesternWeekWithHolidays(BaseCalendarTest):
     @classmethod
     def setup_class(cls):
@@ -411,7 +413,7 @@ class TestCalendarWesternWeekWithHolidays(BaseCalendarTest):
 
     def __init__(self):
         BaseCalendarTest.__init__(self)
-        self.holidays = [parse(x) for x in global_holidays.split('\n')]
+        self.holidays = [parse(x) for x in global_holidays.split('\n') if x]
         self.cal = Calendar(holidays=self.holidays)
         self.cal.warn_on_holiday_exhaustion = False
         rr = rruleset()
@@ -439,6 +441,7 @@ class TestCalendarWesternWeekWithHolidays(BaseCalendarTest):
             count = self.cal.busdaycount('Dec 31, 2009', date2);
             assert count == daycount
 
+
 class TestCalendarCrazyWeekWithHolidays(BaseCalendarTest):
     @classmethod
     def setup_class(cls):
@@ -447,7 +450,7 @@ class TestCalendarCrazyWeekWithHolidays(BaseCalendarTest):
 
     def __init__(self):
         BaseCalendarTest.__init__(self)
-        self.holidays = [parse(x) for x in global_holidays.split('\n')]
+        self.holidays = [parse(x) for x in global_holidays.split('\n') if x]
         self.cal = Calendar(workdays=[0,1,4,6], holidays=self.holidays)
         rr = rruleset()
         rr.rrule(rrule(DAILY,
@@ -460,6 +463,7 @@ class TestCalendarCrazyWeekWithHolidays(BaseCalendarTest):
                                 datetime.datetime(2013,12,31),
                                 inc=True)
 
+
 class TestCalendarCrazyWeek2WithHolidays(BaseCalendarTest):
     @classmethod
     def setup_class(cls):
@@ -468,7 +472,7 @@ class TestCalendarCrazyWeek2WithHolidays(BaseCalendarTest):
 
     def __init__(self):
         BaseCalendarTest.__init__(self)
-        self.holidays = [parse(x) for x in global_holidays.split('\n')]
+        self.holidays = [parse(x) for x in global_holidays.split('\n') if x]
         self.cal = Calendar(workdays=[0], holidays=self.holidays)
         rr = rruleset()
         rr.rrule(rrule(DAILY,

--- a/business_calendar/test/test_business_calendar.py
+++ b/business_calendar/test/test_business_calendar.py
@@ -484,3 +484,75 @@ class TestCalendarCrazyWeek2WithHolidays(BaseCalendarTest):
         self.dates = rr.between(datetime.datetime(2010,1,1),
                                 datetime.datetime(2013,12,31),
                                 inc=True)
+
+
+class TestCalendarWithBusinessDays:
+    def test_weekend_is_business_day(self):
+        busdays = [datetime.date(2018, 4, 28)]
+        cal = Calendar(busdays=busdays)
+
+        next_busday = cal.addbusdays(datetime.date(2018, 4, 27), 1)
+        assert datetime.date(2018, 4, 28) == next_busday
+
+        next_busday = cal.addbusdays(datetime.date(2018, 4, 27), 2)
+        assert datetime.date(2018, 4, 30) == next_busday
+
+        prev_busday = cal.addbusdays(datetime.date(2018, 4, 30), -1)
+        assert datetime.date(2018, 4, 28) == prev_busday
+
+        prev_busday = cal.addbusdays(datetime.date(2018, 4, 30), -2)
+        assert datetime.date(2018, 4, 27) == prev_busday
+
+    def test_busdaycount(self):
+        busdays = [datetime.date(2018, 4, 28)]
+        cal = Calendar(busdays=busdays)
+
+        nbusdays = cal.busdaycount(
+            datetime.date(2018, 4, 27),
+            datetime.date(2018, 4, 30),
+        )
+        assert 2 == nbusdays
+
+        nbusdays = cal.busdaycount(
+            datetime.date(2018, 4, 30),
+            datetime.date(2018, 4, 27),
+        )
+        assert -2 == nbusdays
+
+        # time interval after business day
+        nbusdays = cal.busdaycount(
+            datetime.date(2018, 4, 30),
+            datetime.date(2018, 5, 4),
+        )
+        assert 4 == nbusdays
+
+        nbusdays = cal.busdaycount(
+            datetime.date(2018, 5, 4),
+            datetime.date(2018, 4, 30),
+        )
+        assert -4 == nbusdays
+
+        # time interval before business day
+        nbusdays = cal.busdaycount(
+            datetime.date(2018, 4, 2),
+            datetime.date(2018, 4, 6),
+        )
+        assert 4 == nbusdays
+
+        nbusdays = cal.busdaycount(
+            datetime.date(2018, 4, 6),
+            datetime.date(2018, 4, 2),
+        )
+        assert -4 == nbusdays
+
+    def test_range(self):
+        busdays = [datetime.date(2018, 4, 28)]
+        cal = Calendar(busdays=busdays)
+        busdays = list(cal.range(
+            datetime.date(2018, 4, 27),
+            datetime.date(2018, 4, 30),
+        ))
+        assert [
+            datetime.date(2018, 4, 27),
+            datetime.date(2018, 4, 28),
+        ] == busdays


### PR DESCRIPTION
In some cases, working days are declared non-working days in order to form a longer period of consecutive non-working days. In exchange, weekend days become normal working days. For example, if May 1 falls on a Tuesday, workers in Russia get the day off on Monday and have to work on the previous Sunday instead.

This pull request adds support for such moved working days.